### PR TITLE
Add curl to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN    dpkg --add-architecture i386 \
             automake \
             build-essential \
             cmake \
+            curl \
             g++ \
             gcc \
             gcc-multilib \


### PR DESCRIPTION
Add curl as the various images based on this one now use it (instead of wget) to download package tarballs. We still leave wget in, just in case something else made use of it.