### PR TITLE
Install libglpk-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN    dpkg --add-architecture i386 \
             libcdd-dev \
             libcurl4-openssl-dev \
             libflint-dev \
+            libglpk-dev \
             libgmp-dev \
             libgmpxx4ldbl \
             libmpc-dev \


### PR DESCRIPTION
Without GLPK, `4ti2` does not compile the `groebner` binary, which is needed by `4ti2Interface`.