### PR TITLE
Install texlive-latex-extra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN    dpkg --add-architecture i386 \
             polymake \
             python3-pip \
             sudo \
+            texlive-latex-extra \
             unzip \
             wget \
     && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime


### PR DESCRIPTION
GAPDoc needs enumitem.sty for generating PDF files, which is contained in `texlive-latex-extra`.

167 MB of additional disk space will be used.